### PR TITLE
Update to work with log 0.4 and rustc 1.43

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ license = "MIT"
 keywords = ["kmsg", "log", "logger", "kernel", "dmesg"]
 
 [dependencies]
-log = "*"
+libc = "0.2"
 
-[features]
-nightly = []
+[dependencies.log]
+version = "0.4"
+features = ["std"]


### PR DESCRIPTION
Part of the [systemd/zram-generator](https://github.com/systemd/zram-generator) effort.

Also reimagines the API a bit, what with the changes to `log`, I based it on `simplelog`

This is obviously breaking, but it's not like it built before, so